### PR TITLE
feat: isv suggestions pull id

### DIFF
--- a/packages/engine/src/cli/index.ts
+++ b/packages/engine/src/cli/index.ts
@@ -3,12 +3,14 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
+import * as suggestions from './suggestions';
 import * as synsets from './synsets';
 import * as spreadsheets from './spreadsheets';
 import * as users from './users';
 
 yargs(hideBin(process.argv))
   .scriptName('isv')
+  .command(suggestions as any)
   .command(synsets as any)
   .command(spreadsheets as any)
   .command(users as any)

--- a/packages/engine/src/cli/suggestions-cmd/common.ts
+++ b/packages/engine/src/cli/suggestions-cmd/common.ts
@@ -1,0 +1,32 @@
+import compose from '../../compositionRoot';
+import type { SuggestionsSheet } from '../../google';
+
+export type PullArgv = {
+  subcommand: 'pull';
+  _: string[];
+};
+
+export async function getGoogleGitSyncPrerequisites() {
+  const { fileDatabase, googleAPIs } = await compose();
+
+  const spreadsheetConfig = await fileDatabase.spreadsheets.findById(
+    'new_interslavic_words_list',
+  );
+
+  if (!spreadsheetConfig) {
+    throw new Error(
+      'Cannot find the spreadsheet config for "new_interslavic_words_list"',
+    );
+  }
+
+  const spreadsheet = googleAPIs.spreadsheet(spreadsheetConfig.google_id);
+  const suggestions = await spreadsheet.getSheetByTitle('suggestions');
+  if (!suggestions) {
+    throw new Error('Cannot find the sheet: suggestions');
+  }
+
+  return {
+    suggestions: suggestions as unknown as SuggestionsSheet,
+    multisynsets: fileDatabase.multisynsets,
+  };
+}

--- a/packages/engine/src/cli/suggestions-cmd/index.ts
+++ b/packages/engine/src/cli/suggestions-cmd/index.ts
@@ -1,0 +1,1 @@
+export * from './pull';

--- a/packages/engine/src/cli/suggestions-cmd/pull.ts
+++ b/packages/engine/src/cli/suggestions-cmd/pull.ts
@@ -1,0 +1,20 @@
+import { ImportSuggestions } from '../../sync';
+
+import type { PullArgv } from './common';
+import { getGoogleGitSyncPrerequisites } from './common';
+
+export async function pull(argv: PullArgv) {
+  const { multisynsets, suggestions } = await getGoogleGitSyncPrerequisites();
+
+  const selectedIds = argv._.slice(1);
+  const operation = new ImportSuggestions({
+    multisynsets,
+    selectedIds,
+    suggestions,
+  });
+
+  console.log('Importing suggestions...');
+  await operation.execute();
+}
+
+export {type PullArgv} from './common';

--- a/packages/engine/src/cli/suggestions.ts
+++ b/packages/engine/src/cli/suggestions.ts
@@ -1,0 +1,23 @@
+import type { CommandBuilder } from 'yargs';
+
+import * as subcommand from './suggestions-cmd';
+
+export const command = 'suggestions <subcommand>';
+
+export const describe = 'Imports suggestions from Google Sheets';
+
+export const handler = async (argv: subcommand.PullArgv) => {
+  if (argv.subcommand !== 'pull') {
+    throw new Error(`Unknown subcommand: ${(argv as any).subcommand}`);
+  }
+
+  await subcommand.pull(argv);
+};
+
+export const builder: CommandBuilder<subcommand.PullArgv, any> = {
+  subcommand: {
+    choices: ['pull'],
+    description: 'Subcommand to execute',
+    demandOption: true,
+  },
+};

--- a/packages/engine/src/google/dto/SuggestionsDTO.ts
+++ b/packages/engine/src/google/dto/SuggestionsDTO.ts
@@ -1,0 +1,27 @@
+import type { ArrayMapped } from '@interslavic/database-engine-google';
+
+export type SuggestionsRecord = {
+  id: string;
+  isv: string;
+  addition: string;
+  author: string;
+  partOfSpeech: string;
+  type: string | number;
+  en: string;
+  tags: string;
+  definition: string;
+  ru: string;
+  be: string;
+  uk: string;
+  pl: string;
+  cs: string;
+  sk: string;
+  bg: string;
+  mk: string;
+  sr: string;
+  hr: string;
+  sl: string;
+  comments: string;
+};
+
+export type SuggestionsDTO = ArrayMapped<SuggestionsRecord>;

--- a/packages/engine/src/google/dto/index.ts
+++ b/packages/engine/src/google/dto/index.ts
@@ -1,2 +1,3 @@
+export * from './SuggestionsDTO';
 export * from './WordsDTO';
 export * from './WordsAddLangDTO';

--- a/packages/engine/src/google/mappers/toMultiSynset.ts
+++ b/packages/engine/src/google/mappers/toMultiSynset.ts
@@ -4,17 +4,18 @@ import {
   MultilingualSynset,
 } from '@interslavic/database-engine-core';
 
-import type { WordsDTO, WordsAddLangRecord, WordsRecord } from '../dto';
+import type { WordsAddLangRecord, WordsRecord } from '../dto';
 
-export function toMultiSynset(dto: WordsDTO): MultilingualSynset {
+export function toMultiSynset(dto: WordsRecord): MultilingualSynset {
   const multilingualSynset = new MultilingualSynset();
 
   const debated = new Set<keyof WordsRecord>();
-  for (const key of dto.getKeys()) {
-    const value = `${dto[key]}`.trimStart();
+  const dtoAny = dto as any;
+  for (const key of Object.keys(dto)) {
+    const value = `${dtoAny[key]}`.trimStart();
     if (value.startsWith('#')) {
-      debated.add(key);
-      dto[key] = value.slice(1);
+      debated.add(key as keyof WordsRecord);
+      dtoAny[key] = value.slice(1);
     }
   }
 

--- a/packages/engine/src/google/sheets/WordsSheet.ts
+++ b/packages/engine/src/google/sheets/WordsSheet.ts
@@ -4,3 +4,4 @@ import type { WordsAddLangRecord, WordsRecord } from '../dto';
 
 export type WordsSheet = Sheet<WordsRecord>;
 export type WordsAddLangSheet = Sheet<WordsAddLangRecord>;
+export type SuggestionsSheet = Sheet<WordsAddLangRecord>;

--- a/packages/engine/src/sync/index.ts
+++ b/packages/engine/src/sync/index.ts
@@ -1,1 +1,2 @@
+export * from './suggestions';
 export * from './words';

--- a/packages/engine/src/sync/suggestions/ImportSuggestions.ts
+++ b/packages/engine/src/sync/suggestions/ImportSuggestions.ts
@@ -1,0 +1,90 @@
+import type { MultilingualSynsetRepository } from '@interslavic/database-engine-fs';
+
+import type { SuggestionsDTO, SuggestionsSheet } from '../../google';
+import { toMultiSynset } from '../../google';
+import { log } from '../../utils';
+
+export type ImportSuggestionsOptions = {
+  readonly multisynsets: MultilingualSynsetRepository;
+  readonly selectedIds: string[];
+  readonly suggestions: SuggestionsSheet;
+};
+
+export class ImportSuggestions {
+  protected readonly multisynsets: MultilingualSynsetRepository;
+  protected readonly selectedIds: Set<string>;
+  protected readonly suggestionsSheet: SuggestionsSheet;
+
+  constructor(options: Readonly<ImportSuggestionsOptions>) {
+    this.multisynsets = options.multisynsets;
+    this.selectedIds = new Set(options.selectedIds);
+    this.suggestionsSheet = options.suggestions;
+  }
+
+  public async execute(): Promise<void> {
+    const synsetIds = await this.multisynsets.keys();
+    // eslint-disable-next-line unicorn/no-array-reduce
+    const maxSynsetId = synsetIds.reduce(getMax, 0);
+    const suggestions = await this._getSuggestions();
+    let id = maxSynsetId;
+    for (const suggestion of suggestions) {
+      if (!this.selectedIds.has(suggestion.id)) {
+        continue;
+      }
+
+      id++;
+      const multisynset = toMultiSynset({
+        id,
+        isv: suggestion.isv,
+        addition: suggestion.addition,
+        partOfSpeech: suggestion.partOfSpeech,
+        type: suggestion.type,
+        en: suggestion.en,
+        sameInLanguages: '',
+        genesis: '',
+        ru: suggestion.ru,
+        be: suggestion.be,
+        uk: suggestion.uk,
+        pl: suggestion.pl,
+        cs: suggestion.cs,
+        sk: suggestion.sk,
+        bg: suggestion.bg,
+        mk: suggestion.mk,
+        sr: suggestion.sr,
+        hr: suggestion.hr,
+        sl: suggestion.sl,
+        cu: '',
+        de: '',
+        nl: '',
+        eo: '',
+        frequency: '',
+        intelligibility: '',
+        using_example: '',
+      });
+
+      await this.multisynsets.insert(multisynset);
+    }
+
+    if (id === maxSynsetId) {
+      console.log('No suggestions found with selected ids:', [
+        ...this.selectedIds,
+      ]);
+    }
+  }
+
+  private async _getSuggestions(): Promise<SuggestionsDTO[]> {
+    const sheet = this.suggestionsSheet;
+    return log.trace.complete(
+      { cat: ['gsheets'], tid: ['fetch', sheet.id] },
+      `fetch ${sheet.title}`,
+      async () => {
+        const dtos = (await sheet.getValues()) as unknown as SuggestionsDTO[];
+        return dtos;
+      },
+    );
+  }
+}
+
+function getMax(max: number, value: number): number {
+  return Math.max(max, value);
+}

--- a/packages/engine/src/sync/suggestions/index.ts
+++ b/packages/engine/src/sync/suggestions/index.ts
@@ -1,0 +1,1 @@
+export * from './ImportSuggestions';


### PR DESCRIPTION
Adds new command to import suggested words from [this table](https://docs.google.com/spreadsheets/d/1N79e_yVHDo-d026HljueuKJlAAdeELAiPzdFzdBuKbY/edit#gid=1226657383)., e.g.

```
isv suggestions pull S00755 S00747
```

It creates a new synset XML files in the file database, so you can commit them and suggest, e.g.: https://github.com/medzuslovjansky/database/pull/20/files

