### PR TITLE
feat: add @interslavic/cli package

### DIFF
--- a/packages/cli/.eslintignore
+++ b/packages/cli/.eslintignore
@@ -1,0 +1,2 @@
+/*.js
+/src/sync/backup

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('./dist/cli/index.js');
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@interslavic/cli",
+  "version": "1.1.1",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/medzuslovjansky/database-engine.git",
+    "directory": "packages/cli"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "isv": "cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint . --fix",
+    "lint:ci": "eslint .",
+    "test": ":"
+  },
+  "devDependencies": {
+    "@interslavic/eslint-config-database-engine": "^1.1.1",
+    "@interslavic/jest-config-database-engine": "^1.0.8",
+    "@interslavic/prettier-config-database-engine": "^1.0.8",
+    "@interslavic/typescript-config-database-engine": "^1.1.1",
+    "@types/unist": "^3.0.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@interslavic/utils": "^2.3.2",
+    "remark": "^15.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "tslib": "^2.6.2",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0",
+    "yargs": "^17.7.2"
+  },
+  "license": "GPL-3.0-or-later",
+  "prettier": "@interslavic/prettier-config-database-engine",
+  "eslintConfig": {
+    "extends": "@interslavic/database-engine"
+  },
+  "gitHead": "892bf66e8b7afaa13e5a9dd00ea6fe169ee936cb"
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import * as process from 'node:process';
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import transliterate from './transliterate.js';
+import type { TransliterateArgv } from './transliterate.js';
+
+const cli = yargs(hideBin(process.argv))
+  .scriptName('isv')
+  .usage('Usage: $0 <command> [options]')
+  .usage('\nCommands:\n')
+  .usage('  transliterate  Transliterate plain or Markdown text')
+  .command<TransliterateArgv>(transliterate)
+  .demandCommand(1, 'Please specify a command')
+  .strict()
+  .help()
+  .fail((message, error, yargs) => {
+    if (error) {
+      console.error(error.message + '\n');
+    } else {
+      console.error(message + '\n');
+    }
+    yargs.showHelp();
+    process.exit(1);
+  });
+
+if (process.argv.length === 2) {
+  cli.showHelp();
+} else {
+  cli.parse();
+}

--- a/packages/cli/src/transliterate.ts
+++ b/packages/cli/src/transliterate.ts
@@ -1,0 +1,85 @@
+import * as fs from 'node:fs';
+
+import isv from '@interslavic/utils';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
+import type { Literal } from 'unist';
+import { visit } from 'unist-util-visit';
+import type { CommandModule } from 'yargs';
+
+export interface TransliterateArgv {
+  input?: string;
+  output?: string;
+  format?: 'plain' | 'markdown';
+  script: isv.FlavorisationBCP47Code;
+}
+
+const commandModule: CommandModule<unknown, TransliterateArgv> = {
+  command: 'transliterate',
+  aliases: ['t'],
+  builder: {
+    script: {
+      alias: 's',
+      describe: 'Target script',
+      demandOption: true,
+      choices: Object.values(isv.FlavorisationBCP47),
+    },
+    format: {
+      alias: 'f',
+      describe: 'Input format',
+      choices: ['plain', 'markdown'],
+      default: 'plain',
+    },
+    input: {
+      alias: 'i',
+      describe: 'Input file [default: stdin]',
+      type: 'string',
+    },
+    output: {
+      alias: 'o',
+      describe: 'Output file [default: stdout]',
+      type: 'string',
+    },
+  },
+  async handler(argv) {
+    const { format, script, input, output } = argv;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(() => (tree) => {
+        visit(tree, 'text', (node: Literal) => {
+          node.value = isv.transliterate(String(node.value), script);
+        });
+      })
+      .use(remarkStringify);
+
+    let inputData = '';
+
+    if (input) {
+      inputData = await fs.promises.readFile(input, 'utf8');
+    } else {
+      const stdin = process.stdin;
+      stdin.setEncoding('utf8');
+      stdin.on('data', (chunk) => {
+        inputData += chunk;
+      });
+      await new Promise((resolve) => {
+        stdin.on('end', resolve);
+      });
+    }
+
+    const file =
+      format === 'plain'
+        ? isv.transliterate(inputData, script)
+        : await processor.process(inputData);
+
+    if (output) {
+      await fs.promises.writeFile(output, String(file));
+    } else {
+      process.stdout.write(String(file));
+    }
+  },
+};
+
+export default commandModule;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@interslavic/typescript-config-database-engine",
+  "compilerOptions": {
+    "module": "ES2022",
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This package can be installed as `npm install -g @interslavic/cli` and used like:

```
isv transliterate -s art-Cyrl-x-interslv -f markdown -i input.md -o output.md
cat file.txt | isv transliterate -s art-Latn-x-interslv
```

and so on.